### PR TITLE
Android-x86.xml: Revert Blissify commit

### DIFF
--- a/android-x86.xml
+++ b/android-x86.xml
@@ -88,8 +88,9 @@
 	-->
 	<project path="external/libdrm" name="platform_external_libdrm" remote="BR-x86" revision="2.4.100-ax86-ma" />
 	<project path="external/libffi" name="platform/external/libffi" remote="x86" revision="q-x86" />
+	<project path="external/llvm90" name="platform_external_llvm" remote="BR-x86" revision="q10-x86-03.31.20" />
+	<!-- 
 	<project path="external/llvm90" name="platform/external/llvm" remote="x86" revision="q-x86" />
-	<!--
 	<project path="external/mesa" name="platform/external/mesa" remote="x86" revision="q-x86" /> 
 	-->
 	<project path="external/mesa" name="platform_mesa" remote="BR-x86" revision="19.3.4-ax86-q" />

--- a/android-x86.xml
+++ b/android-x86.xml
@@ -125,7 +125,7 @@
 	<!-- <project path="hardware/x86power" name="platform/hardware/x86power" remote="x86" revision="q-x86" groups="notdefault" /> -->
 	<!--
 	<project path="packages/apps/Camera2" name="platform/packages/apps/Camera2" remote="x86" revision="q-x86" />
-	<!-- <project path="packages/apps/Eleven" name="platform/packages/apps/Eleven" remote="x86" revision="q-x86" /> -->
+	<project path="packages/apps/Eleven" name="platform/packages/apps/Eleven" remote="x86" revision="q-x86" /> 
 	<project path="packages/apps/Gallery2" name="platform/packages/apps/Gallery2" remote="x86" revision="q-x86" />
 	-->
 	<project path="packages/apps/Launcher3" name="platform_packages_apps_Launcher3" remote="BR-x86" revision="q-x86-03.28.20" />

--- a/android-x86.xml
+++ b/android-x86.xml
@@ -32,7 +32,7 @@
 	<!--
 	<project name="vendor_bliss_priv" path="vendor/google/chromeos-x86" remote="BR-x86" revision="p9" />
 	-->
-	<project path="packages/apps/Blissify" name="platform_packages_apps_Blissify" remote="BR-x86" revision="q10-x86-03.25.20" /> 
+	<project path="packages/apps/Blissify" name="platform_packages_apps_Blissify" remote="BR-x86" revision="708fba99778c2c038664b627e7769e0c7165a982" /> 
 	<project path="packages/apps/ThemePicker" name="platform_packages_apps_ThemePicker" remote="BR-x86" revision="q10-x86-03.28.20"  /> 
 	
 	<!-- Extra features from Spurv-->


### PR DESCRIPTION
Temporary fix to get Blissify buildable. The recent Blissify uses Java class `com.android.internal.util.slim` which probably hasn't been upstreamed within googlesource of `q10-x86`. Close this once the googlesource has been adapted to use the mentioned class